### PR TITLE
Experimental: Smart Probes in ivfflat indexes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ PG_CFLAGS += $(OPTFLAGS) -ftree-vectorize -fassociative-math -fno-signed-zeros -
 # Debug Clang auto-vectorization
 # PG_CFLAGS += -Rpass=loop-vectorize -Rpass-analysis=loop-vectorize
 
+# PG_CFLAGS += -DIVFFLAT_BENCH
+
 all: sql/$(EXTENSION)--$(EXTVERSION).sql
 
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql

--- a/README.md
+++ b/README.md
@@ -390,6 +390,37 @@ SELECT ...
 COMMIT;
 ```
 
+### Smart Probes
+
+Enable smart probe selection for improved performance on clustered data (off by default).
+
+```sql
+SET ivfflat.smart_probes = on;
+```
+
+This optimization provides the best performance improvements with clustered data
+where vectors are grouped into distinct regions. For uniformly distributed data,
+the performance impact is minimal.
+
+Tune the distance threshold for early termination (2.0 by default)
+
+```sql
+SET ivfflat.smart_probes_distance_threshold = 3.0;
+```
+
+Higher values are more conservative (better accuracy), lower values are more
+aggressive (better performance). Range is 1.1 to 100.0.
+
+Use `SET LOCAL` to enable it for a single query
+
+```sql
+BEGIN;
+SET LOCAL ivfflat.smart_probes = on;
+SET LOCAL ivfflat.smart_probes_distance_threshold = 2.5;
+SELECT ...
+COMMIT;
+```
+
 ### Index Build Time
 
 Speed up index creation on large tables by increasing the number of parallel workers (2 by default)

--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -19,6 +19,8 @@
 int			ivfflat_probes;
 int			ivfflat_iterative_scan;
 int			ivfflat_max_probes;
+bool		ivfflat_smart_probes;
+double		ivfflat_smart_probes_distance_threshold;
 static relopt_kind ivfflat_relopt_kind;
 
 static const struct config_enum_entry ivfflat_iterative_scan_options[] = {
@@ -49,6 +51,14 @@ IvfflatInit(void)
 	DefineCustomIntVariable("ivfflat.max_probes", "Sets the max number of probes for iterative scans",
 							NULL, &ivfflat_max_probes,
 							IVFFLAT_MAX_LISTS, IVFFLAT_MIN_LISTS, IVFFLAT_MAX_LISTS, PGC_USERSET, 0, NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("ivfflat.smart_probes", "Enables smart probe selection optimization",
+							 "When enabled, uses adaptive probe selection and early termination for better performance.",
+							 &ivfflat_smart_probes, false, PGC_USERSET, 0, NULL, NULL, NULL);
+
+	DefineCustomRealVariable("ivfflat.smart_probes_distance_threshold", "Distance threshold for smart probe early termination",
+							 "Higher values are more conservative (better accuracy), lower values are more aggressive (better performance). Range is 1.1 to 1000.0.",
+							 &ivfflat_smart_probes_distance_threshold, 2.0, 1.1, 1000.0, PGC_USERSET, 0, NULL, NULL, NULL);
 
 	MarkGUCPrefixReserved("ivfflat");
 }

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -84,6 +84,8 @@
 extern int	ivfflat_probes;
 extern int	ivfflat_iterative_scan;
 extern int	ivfflat_max_probes;
+extern bool	ivfflat_smart_probes;
+extern double	ivfflat_smart_probes_distance_threshold;
 
 typedef enum IvfflatIterativeScanMode
 {
@@ -259,6 +261,7 @@ typedef struct IvfflatScanOpaqueData
 	const		IvfflatTypeInfo *typeInfo;
 	int			probes;
 	int			maxProbes;
+	int			adaptiveProbes;
 	int			dimensions;
 	bool		first;
 	Datum		value;


### PR DESCRIPTION
Enable smart probe selection for improved performance on clustered data (off by default).

```sql
SET ivfflat.smart_probes = on;
```

This optimization provides the best performance improvements with clustered data where vectors are grouped into distinct regions. For uniformly distributed data, the performance impact is minimal.

Tune the distance threshold for early termination (2.0 by default)

```sql
SET ivfflat.smart_probes_distance_threshold = 3.0;
```

Higher values are more conservative (better accuracy), lower values are more aggressive (better performance). Range is 1.1 to 1000.0.

## Benchmarks

```
Generating results...
 function_name  |                       test_name                       | Median Time (ms) | 95th Percentile (ms) | 99th Percentile (ms) | Standard Deviation (ms)
----------------+-------------------------------------------------------+------------------+----------------------+----------------------+-------------------------
 idx_ivfflat_l2 | ivfflat_l2_distance (probes = 10, smart_probes = OFF) |            0.094 |                0.107 |                0.116 |                   0.009
 idx_ivfflat_l2 | ivfflat_l2_distance (probes = 10, smart_probes = ON)  |            0.048 |                0.058 |                0.066 |                   0.006
 idx_ivfflat_l2 | ivfflat_l2_distance (probes = 5, smart_probes = OFF)  |            0.051 |                0.056 |                0.065 |                   0.005
 idx_ivfflat_l2 | ivfflat_l2_distance (probes = 5, smart_probes = ON)   |            0.028 |                0.031 |                0.035 |                   0.003
 idx_ivfflat_l2 | ivfflat_l2_distance (probes = 8, smart_probes = OFF)  |            0.082 |                0.089 |                0.105 |                   0.008
 idx_ivfflat_l2 | ivfflat_l2_distance (probes = 8, smart_probes = ON)   |            0.041 |                0.050 |                0.073 |                   0.009
(6 rows)
```

Benchmarks have shown somewhat mixed results as table sizes, lists, and probe count changes. I'm trying to understand this relationship better so I can be sure of if/when smart probes makes a noticable difference.